### PR TITLE
import Sequence from collections.abc : stop warning in py 3.3+

### DIFF
--- a/blynclight/blynclight.py
+++ b/blynclight/blynclight.py
@@ -1,4 +1,7 @@
-from collections import Sequence
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 from contextlib import contextmanager
 from enum import Enum
 from typing import Dict, List, Tuple, Union


### PR DESCRIPTION
Sequence should be imported from collections.abc instead of collections since Python 3.3. A warning is printed starting with Python 3.7 and in Python 3.9 the new import location will be required.

This PR imports from collections.abc while still falling back to importing from collections for older Python versions.